### PR TITLE
chore(LIVE-563): Upgrade to Ruby 3.3, Bundler 2.5.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 2.7
+          ruby-version: 3.3
       - name: Run tests
         run: bundle exec rspec
       - name: Setup RubyGems

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.7]
+        ruby-version: [3.3]
 
     steps:
       - uses: actions/checkout@v4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,37 +7,42 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    actionview (6.1.7.7)
-      activesupport (= 6.1.7.7)
+    actionview (6.1.7.8)
+      activesupport (= 6.1.7.8)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activesupport (6.1.7.7)
+    activesupport (6.1.7.8)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     builder (3.2.4)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.1)
     crass (1.0.6)
     diff-lcs (1.5.1)
     erubi (1.12.0)
-    i18n (1.14.1)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mini_portile2 (2.8.5)
-    minitest (5.22.2)
-    nokogiri (1.15.5)
-      mini_portile2 (~> 2.8.2)
+    minitest (5.23.1)
+    nokogiri (1.16.5-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.15.5-java)
+    nokogiri (1.16.5-arm-linux)
       racc (~> 1.4)
-    racc (1.7.3)
-    racc (1.7.3-java)
+    nokogiri (1.16.5-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.5-x86-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.5-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.5-x86_64-linux)
+      racc (~> 1.4)
+    racc (1.8.0)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -54,17 +59,21 @@ GEM
     rspec-expectations (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.0)
+    rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.6.13)
+    zeitwerk (2.6.15)
 
 PLATFORMS
-  java
-  ruby
+  aarch64-linux
+  arm-linux
+  arm64-darwin
+  x86-linux
+  x86_64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   actionview (>= 6.0.3.3, < 7.0)
@@ -72,4 +81,4 @@ DEPENDENCIES
   rspec (~> 3.13)
 
 BUNDLED WITH
-   1.17.3
+   2.5.11


### PR DESCRIPTION
# DO NOT MERGE
This is a test PR, intending to explore upgrading this gem to `Ruby v3.3`, bundled with `Bundler 2.5.11`